### PR TITLE
Minor improvement in accessibility (outline for buttons in :focus)

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
       cursor: pointer;
       border-radius: 1em;
       background-color: #efefef;
-      transition: 1s ease;
+      transition: .4s ease;
     }
     button:before{
       content: '';
@@ -45,6 +45,7 @@
 
     button:focus{
       outline: none !important;
+      box-shadow: 0px 0 1em rgb(0, 99, 234), 0 0 2em #FFF;
     }
 
     button::-moz-focus-inner {

--- a/sketch.js
+++ b/sketch.js
@@ -54,7 +54,7 @@ function setup() {
 
 
   for (let i = 0; i < buttons.length; i++) {
-    buttons[i].mousePressed(sendData);
+    buttons[i].mouseClicked(sendData);
   }
 
   // Commenting out the loading of data for the webpage running


### PR DESCRIPTION
Buttons should be highlighted on tab and buttons should be pressable by enter/space keys. 

![peek 2018-06-14 12-06](https://user-images.githubusercontent.com/1612488/41420663-62eeec7e-6fcb-11e8-9ac4-1f0f7273102c.gif)


